### PR TITLE
Corrections for FreeBSD on Raspberry Pi

### DIFF
--- a/extpkgs.sh
+++ b/extpkgs.sh
@@ -528,6 +528,10 @@ get_default_cpu()
       default_cpu="x86"
       ;;
 
+    arm64*)
+      default_cpu="aarch64"
+      ;;
+
     arm*)
       default_cpu="arm"
       ;;


### PR DESCRIPTION
Correct arm64/aarch64 CPU for FreeBSD on Raspberry Pi